### PR TITLE
Sandbox Django version 3.0.8 (Issue #8)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,9 @@ setup(
             'dact-test = dact.__main__:testing'
         ]
     },
+    install_requires=[
+        'django==3.0.8'
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",


### PR DESCRIPTION
Initially, kept a requirement to download a specific version of Django in this PR. 